### PR TITLE
Fix absolute line number when folding

### DIFF
--- a/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/RelativeLineNumberColumn.java
+++ b/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/RelativeLineNumberColumn.java
@@ -54,7 +54,7 @@ public class RelativeLineNumberColumn extends LineNumberRulerColumn implements I
 		int displayedLine;
 		char prefix;
 		if (showCurrentLineNumberAbsolute && lineDelta == 0) {
-			displayedLine = widgetLine + 1;
+			displayedLine = line + 1;
 			prefix = CURRENT_LINE_PREFIX;
 		} else {
 			displayedLine = lineDelta;


### PR DESCRIPTION
When some code was folded, the absolute line number calculation was
based on the visible lines. Instead it should use the real line number
of the file.

Fixes #5 