### PR TITLE
Configurable prefix for absolute line number

### DIFF
--- a/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/preferences/PreferenceConstants.java
+++ b/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/preferences/PreferenceConstants.java
@@ -3,5 +3,8 @@ package com.github.matf.relativenumberruler.preferences;
 public class PreferenceConstants {
 
 	public static final String SHOW_CURRENT_LINE_NUMBER_ABSOLUTE = "showCurrentLineNumberAbsolute";
+
+	public static final String CURRENT_LINE_PREFIX = "currentLinePrefix";
+	public static final String CURRENT_LINE_PREFIX_DEFAULT = ">";
 	
 }

--- a/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/preferences/PreferenceInitializer.java
+++ b/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/preferences/PreferenceInitializer.java
@@ -10,6 +10,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	public void initializeDefaultPreferences() {
 		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 		store.setDefault(PreferenceConstants.SHOW_CURRENT_LINE_NUMBER_ABSOLUTE, false);
+		store.setDefault(PreferenceConstants.CURRENT_LINE_PREFIX,
+				PreferenceConstants.CURRENT_LINE_PREFIX_DEFAULT);
 	}
 
 }

--- a/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/preferences/RelativeNumberRulerPreferencePage.java
+++ b/com.github.matf.relativenumberruler/src/com/github/matf/relativenumberruler/preferences/RelativeNumberRulerPreferencePage.java
@@ -18,6 +18,11 @@ public class RelativeNumberRulerPreferencePage extends
 				PreferenceConstants.SHOW_CURRENT_LINE_NUMBER_ABSOLUTE,
 				"&Show absolute value for current line number",
 				getFieldEditorParent()));
+		
+		addField(new StringFieldEditor(
+				PreferenceConstants.CURRENT_LINE_PREFIX,
+				"&Prefix for absolute value of current line",
+				getFieldEditorParent()));
 	}
 
 	public void init(IWorkbench workbench) {


### PR DESCRIPTION
If configured that the absolute line number should be shown for the
current line, a ">" was added as prefix. This is now configurable, so the
prefix can be changed to something else, or removed completely.
