### PR TITLE
Keybindings for relative jumps

### DIFF
--- a/com.github.matf.relativenumberruler/plugin.xml
+++ b/com.github.matf.relativenumberruler/plugin.xml
@@ -1,36 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension
-         point="org.eclipse.ui.workbench.texteditor.rulerColumns">
-      <column
-            class="com.github.matf.relativenumberruler.RelativeLineNumberColumn"
-            enabled="true"
-            global="true"
-            id="com.github.matf.relativenumberruler"
-            includeInMenu="true"
-            name="Relative Line Number Ruler">
-         <placement
-               gravity="1.0">
-         </placement>
-         <targetClass
-               class="org.eclipse.ui.texteditor.AbstractDecoratedTextEditor">
-         </targetClass>
-      </column>
-   </extension>
-   <extension
-         point="org.eclipse.ui.preferencePages">
-      <page
-            class="com.github.matf.relativenumberruler.preferences.RelativeNumberRulerPreferencePage"
-            id="com.github.matf.relativenumberruler.preferences.RelativeNumberRulerPreferencePage"
-            name="Relative Number Ruler">
-      </page>
-   </extension>
-   <extension
-         point="org.eclipse.core.runtime.preferences">
-      <initializer
-            class="com.github.matf.relativenumberruler.preferences.PreferenceInitializer">
-      </initializer>
-   </extension>
-
+	<extension
+		point="org.eclipse.ui.workbench.texteditor.rulerColumns">
+		<column
+			class="com.github.matf.relativenumberruler.RelativeLineNumberColumn"
+			enabled="true"
+			global="true"
+			id="com.github.matf.relativenumberruler"
+			includeInMenu="true"
+			name="Relative Line Number Ruler">
+			<placement
+				gravity="1.0">
+			</placement>
+			<targetClass
+				class="org.eclipse.ui.texteditor.AbstractDecoratedTextEditor">
+			</targetClass>
+		</column>
+	</extension>
+	<extension
+		point="org.eclipse.ui.preferencePages">
+		<page
+			class="com.github.matf.relativenumberruler.preferences.RelativeNumberRulerPreferencePage"
+			id="com.github.matf.relativenumberruler.preferences.RelativeNumberRulerPreferencePage"
+			name="Relative Number Ruler">
+		</page>
+	</extension>
+	<extension
+		point="org.eclipse.core.runtime.preferences">
+		<initializer
+			class="com.github.matf.relativenumberruler.preferences.PreferenceInitializer">
+		</initializer>
+	</extension>
+	<extension
+		point="org.eclipse.ui.commands">
+		<category
+			id="com.github.matf.relativenumberruler.bindings"
+			name="Relative Number Ruler">
+		</category>
+		<command
+			categoryId="com.github.matf.relativenumberruler.bindings"
+			name="Relative number ruler jump up"
+			id="com.github.matf.relativenumberruler.bindings.RelativeJumpUp"
+			description="Go up specified amount of lines according to relative number ruler">
+		</command>
+		<command
+			categoryId="com.github.matf.relativenumberruler.bindings"
+			name="Relative number ruler jump down"
+			id="com.github.matf.relativenumberruler.bindings.RelativeJumpDown"
+			description="Go down specified amount of lines according to relative number ruler">
+		</command>
+	</extension>
+	<extension
+		point="org.eclipse.ui.bindings">
+		<key sequence="Alt+K"
+			commandId="com.github.matf.relativenumberruler.bindings.RelativeJumpUp"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" />
+		<key sequence="Alt+J"
+			commandId="com.github.matf.relativenumberruler.bindings.RelativeJumpDown"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" />
+	</extension>
+	<extension
+		point="org.eclipse.ui.handlers">
+		<handler
+			class="bindings.RelativeJumpUp"
+			commandId="com.github.matf.relativenumberruler.bindings.RelativeJumpUp">
+		</handler>
+		<handler
+			class="bindings.RelativeJumpDown"
+			commandId="com.github.matf.relativenumberruler.bindings.RelativeJumpDown">
+		</handler>
+	</extension>
 </plugin>

--- a/com.github.matf.relativenumberruler/src/bindings/RelativeJumpDown.java
+++ b/com.github.matf.relativenumberruler/src/bindings/RelativeJumpDown.java
@@ -1,0 +1,20 @@
+package bindings;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.InputDialog;
+import org.eclipse.swt.widgets.Display;
+
+public class RelativeJumpDown extends AbstractHandler  {
+
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		InputDialog dialog = new InputDialog(Display.getDefault().getActiveShell(), "Relative jump down",
+				"Enter number of lines to jump down:", "0", null);
+		dialog.open();
+		int offset = Math.abs(Integer.parseInt(dialog.getValue()));
+		RelativeJumpUtils.jump(event, offset);
+		return null;
+	}
+
+}

--- a/com.github.matf.relativenumberruler/src/bindings/RelativeJumpUp.java
+++ b/com.github.matf.relativenumberruler/src/bindings/RelativeJumpUp.java
@@ -1,0 +1,20 @@
+package bindings;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.InputDialog;
+import org.eclipse.swt.widgets.Display;
+
+public class RelativeJumpUp extends AbstractHandler  {
+
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		InputDialog dialog = new InputDialog(Display.getDefault().getActiveShell(), "Relative jump up",
+				"Enter number of lines to jump up:", "0", null);
+		dialog.open();
+		int offset = Math.abs(Integer.parseInt(dialog.getValue())) * -1;
+		RelativeJumpUtils.jump(event, offset);
+		return null;
+	}
+
+}

--- a/com.github.matf.relativenumberruler/src/bindings/RelativeJumpUtils.java
+++ b/com.github.matf.relativenumberruler/src/bindings/RelativeJumpUtils.java
@@ -1,0 +1,54 @@
+package bindings;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public class RelativeJumpUtils {
+
+	public static void jump(ExecutionEvent event, int offset) {
+		IEditorPart editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+		Control control = editor.getAdapter(Control.class);
+		if (!(control instanceof StyledText)) {
+			return;
+		}
+		IEditorPart editorPart = HandlerUtil.getActiveEditor(event);
+		ITextEditor textEditor;
+		if (editorPart instanceof ITextEditor) {
+			textEditor = (ITextEditor) editorPart;
+		} else {
+			textEditor = editorPart.getAdapter(ITextEditor.class);
+			if (textEditor == null) {
+				return;
+			}
+		}
+
+		ISelectionProvider selectionProvider = textEditor.getSelectionProvider();
+		ISelection selection = selectionProvider.getSelection();
+		if (!(selection instanceof ITextSelection)) {
+			return;
+		}
+		ITextSelection textSelection = (ITextSelection) selection;
+		int currentLine = textSelection.getStartLine() + 1; // Convert 0-based to 1-based index
+		int newLine = currentLine + offset;
+		IDocumentProvider documentProvider = textEditor.getDocumentProvider();
+		IDocument document = documentProvider.getDocument(textEditor.getEditorInput());
+		try {
+			int lineOffset = document.getLineOffset(newLine - 1); // convert back to 0-based
+			textEditor.selectAndReveal(lineOffset, 0);
+		} catch (BadLocationException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Default keybindings are set to ALT+J = jump down and ALT+K = jump up. It works similar to CTRL+L which jumps to a absolute line in the file. Popup window will appear and asks you to enter the number of lines to jump, you do, hit enter and cursor is moved. Better keybindings might be CTRL+J/K but those are taken by incremental find and find next so I settled for ALT. User can change it in preferences under names "Relative number ruler jump down/up"

Tested in java, properties and xml files. I also tried to install Vim-vrapper and it works fine with it as well. 